### PR TITLE
support for certificates, optional bigip sync

### DIFF
--- a/iworkflow_plugin/service.py
+++ b/iworkflow_plugin/service.py
@@ -38,10 +38,11 @@ def create_service(vars,
                    tables,
                    properties,
                    connection_params,
-                   bigip_params,
                    reference_hostname,
                    retry_interval,
-                   ctx):
+                   ctx,
+                   serverTierSslCerts=None,
+                   bigip_params=None):
     """
     Creates request payload
     and sends a 'create service' request
@@ -62,6 +63,7 @@ def create_service(vars,
                                 vars,
                                 tables,
                                 properties,
+                                serverTierSslCerts,
                                 reference_hostname,
                                 ctx)
 
@@ -69,12 +71,13 @@ def create_service(vars,
                             retry_interval,
                             ctx)
 
-    iworkflow_service.sync(bigip_params.get(PARAMS_IP),
-                           bigip_params.get(PARAMS_SYNC_GROUP),
-                           bigip_params.get(PARAMS_USER),
-                           bigip_params.get(PARAMS_PASSWORD),
-                           retry_interval
-                           )
+    if bigip_params is not None:
+        iworkflow_service.sync(bigip_params.get(PARAMS_IP),
+                               bigip_params.get(PARAMS_SYNC_GROUP),
+                               bigip_params.get(PARAMS_USER),
+                               bigip_params.get(PARAMS_PASSWORD),
+                               retry_interval
+                               )
 
 
 @load_connection_params
@@ -125,6 +128,7 @@ def _create_service_request(iworkflow_service,
                             vars,
                             tables,
                             properties,
+                            serverTierSslCerts,
                             reference_hostname,
                             ctx):
     try:
@@ -132,6 +136,7 @@ def _create_service_request(iworkflow_service,
                                          vars,
                                          tables,
                                          properties,
+                                         serverTierSslCerts,
                                          reference_hostname)
         ctx.logger.info("Service {0} has been requested".format(
             iworkflow_service.service_name))

--- a/iworkflow_sdk/iworkflow.py
+++ b/iworkflow_sdk/iworkflow.py
@@ -42,6 +42,7 @@ class IWorkflowService:
                        vars,
                        tables,
                        properties,
+                       serverTierSslCerts,
                        reference_hostname):
 
         data = payload.create_payload(self.tenant_name,
@@ -50,6 +51,7 @@ class IWorkflowService:
                                       vars,
                                       tables,
                                       properties,
+                                      serverTierSslCerts,
                                       self._get_proto(),
                                       reference_hostname,
                                       self.connection_params.get("port"))

--- a/iworkflow_sdk/payload.py
+++ b/iworkflow_sdk/payload.py
@@ -24,6 +24,7 @@ PAYLOAD_KEY_VARS = "vars"
 PAYLOAD_KEY_TABLES = "tables"
 PAYLOAD_KEY_PROPERTIES = "properties"
 PAYLOAD_KEY_LINK = "link"
+PAYLOAD_KEY_SSLCERTS = "serverTierSslCerts"
 
 
 def create_payload(tenant_name,
@@ -32,6 +33,7 @@ def create_payload(tenant_name,
                    vars,
                    tables,
                    properties,
+                   serverTierSslCerts,
                    proto,
                    reference_hostname,
                    reference_port):
@@ -49,6 +51,8 @@ def create_payload(tenant_name,
     result.update(_vars(vars))
     result.update(_tables(tables))
     result.update(_properties(properties))
+    if serverTierSslCerts is not None:
+        result.update(_certs(serverTierSslCerts))
 
     return result
 
@@ -98,3 +102,6 @@ def _tables(tables):
 
 def _properties(properties):
     return {PAYLOAD_KEY_PROPERTIES: properties}
+
+def _certs(serverTierSslCerts):
+    return {PAYLOAD_KEY_SSLCERTS: serverTierSslCerts}

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -16,7 +16,7 @@
 plugins:
   iworkflow:
     package_name: cloudify-iworkflow-plugin
-    package_version: '1.0'
+    package_version: '1.1'
     executor: central_deployment_agent
 
 node_types:
@@ -63,6 +63,7 @@ node_types:
       cloudify.interfaces.lifecycle:
         create:
           implementation: iworkflow.iworkflow_plugin.service.create_service
+          max_retries: 3
           inputs:
             vars:
               default: []
@@ -70,10 +71,16 @@ node_types:
               default: []
             properties:
               default: []
+            serverTierSslCerts:
+              default: 
+            bigip_params:
+              default: 
             reference_hostname:
               type: string
+              default: localhost
             retry_interval:
               type: integer
               default: 10
         delete:
           implementation: iworkflow.iworkflow_plugin.service.delete_service
+          max_retries: 3

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ from setuptools import setup
 
 setup(
     name='cloudify-iworkflow-plugin',
-    version='1.0',
+    version='1.1',
     author='Cloudify',
     author_email='hello@cloudify.co',
     license='LICENSE',


### PR DESCRIPTION
This allows support for iWorkflow templates that require ssl certificates to be used.
It also makes it so the BigIP sync is optional.

----- Example
  ltm:
    type: cloudify.iworkflow.Service
    properties:
      template_name: https-ssl-offload_standard 
      tenant_name: { get_attribute: [credentials, iworkflow_tenant] }
      service_name: { concat: [ {get_input: deployment_name} , '.ltm' ] }
    interfaces:
      cloudify.interfaces.lifecycle:
        create:
          implementation: iworkflow.iworkflow_plugin.service.create_service
          max_retries: 0
          inputs:
            vars: 
              - name: pool__addr
                value: *vip
              - name: pool__port
                value: 443
              - name: vs__ProfileClientSSLCert
                value: "cert-passed-via-serverTierSslCerts"
              - name: vs__ProfileClientSSLKey
                value: "key-passed-via-serverTierSslCerts"
              #- name: vs__ProfileClientSSLChain   #alternate method of providing certs as a bundle
              #  value: 
            tables:
              - name: monitor__Monitors
                columns:
                  - Name
                rows:
                  - - /Common/https
              - name: pool__Members
                columns:
                  - IPAddress
                  - Port
                rows:
                  *pool_members  
            properties:
              - id: cloudConnectorReference
                isRequired: false
                value: { concat: [ "https://localhost/mgmt/cm/cloud/connectors/local/", { get_attribute: [credentials, iworkflow_cloud_id] } ] }
            serverTierSslCerts:
              - tier: Servers
                certificateText: *certificate
                privateKeyText: *certificate_key
            #bigip_params:  #optional now
            #  ip: {get_attribute: [bigip_credentials, ip] }
            #  user: {get_attribute: [bigip_credentials, user] }
            #  password: {get_attribute: [bigip_credentials, password] }
            #  sync_group: { get_attribute: [bigip_credentials, sync_group] }
        delete:
          implementation: iworkflow.iworkflow_plugin.service.delete_service
    relationships:
      - type: cloudify.relationships.contained_in
        target: iworkflow